### PR TITLE
Choose which field consider when parsing the memory usage

### DIFF
--- a/memusage.h
+++ b/memusage.h
@@ -1,7 +1,11 @@
 #ifndef MEMUSAGE_H
 #define MEMUSAGE_H
 
-int memusage (pid_t pid);
+#define MEM_VMDATA  0
+#define MEM_VMRSS   1
+#define MEM_VMHWM   2
+
+int memusage (pid_t pid, char which);
 void memusage_init (void);
 void memusage_close (void);
 

--- a/platform/bsd/memusage.c
+++ b/platform/bsd/memusage.c
@@ -3,6 +3,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <kvm.h>
+#include <stdio.h>
 #include <sys/sysctl.h>
 #include <sys/user.h>
 #include <sys/resource.h>
@@ -26,10 +27,14 @@ void memusage_init (void)
     error("memusage_init: %s", errbuf);
 }
 
-int memusage (pid_t pid)
+int memusage (pid_t pid, char mem)
 {
   struct kinfo_proc *kp;
   int cnt = -1;
+
+  // Ignore the mem param
+  if (mem != MEM_VMDATA)
+    fprintf(stderr, "Warning: Flags involving VmData/VmRSS/VmHWM are ignored.\n");
 
   kp = kvm_getprocs(kd, KERN_PROC_PID, pid, &cnt);
   if ((kp == NULL && cnt > 0) || (kp != NULL && cnt < 0))

--- a/platform/linux/memusage.c
+++ b/platform/linux/memusage.c
@@ -15,11 +15,21 @@ void memusage_init (void)
 {
 }
 
-int memusage (pid_t pid)
+int memusage (pid_t pid, char mem)
 {
-  char a[SIZE], *p, *q;
+  char a[SIZE], *p, *q, *mem_hdr;
   int data, stack;
   int n, v, fd;
+
+  if (mem == MEM_VMDATA){
+    mem_hdr = "VmData:";
+  }else if (mem == MEM_VMHWM){
+    mem_hdr = "VmHWM:";
+  }else if (mem == MEM_VMRSS){
+    mem_hdr = "VmRSS:";
+  }else{
+    error ("mem param must be one of: MEM_VMDATA, MEM_VMHWM, MEM_VMRSS");
+  }
 
   p = a;
   sprintf (p, "/proc/%d/status", pid);
@@ -44,7 +54,7 @@ int memusage (pid_t pid)
     error (NULL);
 
   data = stack = 0;
-  q = strstr (p, "VmData:");
+  q = strstr (p, mem_hdr);
   if (q != NULL)
     {
       sscanf (q, "%*s %d", &data);

--- a/safeexec.c
+++ b/safeexec.c
@@ -37,7 +37,7 @@
 #define NICE_LEVEL      15
 #define LARGECONST 4194304
 
-struct config profile = { 1, 32768, 0, 0, 8192, 8192, 0, 10, 5000, 65535 };
+struct config profile = { 1, 32768, 0, 0, 8192, 8192, 0, 10, 5000, 65535, MEM_VMDATA };
 struct config *pdefault = &profile;
 
 pid_t pid;			/* is global, because we kill the proccess in alarm handler */
@@ -253,7 +253,16 @@ char **parse (char **p)
                 silent = 1;
                 state = PARSE;
               }
-            else
+            else if (strcmp (*p, "--vmdata") == 0) {
+              profile.mem = MEM_VMDATA;
+              state = PARSE;
+            }else if (strcmp (*p, "--vmrss") == 0) {
+              profile.mem = MEM_VMRSS;
+              state = PARSE;
+            }else if (strcmp (*p, "--vmhwm") == 0) {
+              profile.mem = MEM_VMHWM;
+              state = PARSE;
+            }else
               {
                 fprintf (stderr, "error: Invalid option: %s\n", *p);
                 state = ERROR;
@@ -339,6 +348,9 @@ void printusage (char **p)
   fprintf (stderr, "\t--usage   <filename>          Report statistics to ... (default: stderr)\n");
   fprintf (stderr, "\t--chroot  <path>              Directory to chrooted (default: /tmp)\n");
   fprintf (stderr, "\t--error   <path>              Print stderr to file (default: /dev/null)\n");
+  fprintf (stderr, "\t--vmdata                      Parse the memory from the VmData field (default)\n");
+  fprintf (stderr, "\t--vmrss                       Parse the memory from the VmRSS field\n");
+  fprintf (stderr, "\t--vmhwm                       Parse the memory from the VmHWM field\n");
 }
 
 void wallclock (int v)
@@ -509,7 +521,7 @@ int main (int argc, char **argv, char **envp)
           do
             {
               msleep (INTERVAL);
-              memused = memusage (pid);
+              memused = memusage (pid, profile.mem);
               if (memused > -1)
                 {
                   mem = max (mem, memused);

--- a/safeexec.h
+++ b/safeexec.h
@@ -19,6 +19,8 @@ struct config
 
   uid_t minuid;
   uid_t maxuid;
+
+  char mem;
 };
 
 #endif


### PR DESCRIPTION
Add flags to specify which of the fields listed in `/proc/PID/status` must be used to parse the memory usage of the child process.
