### PR TITLE
Allow --stack 0 to use system default

### DIFF
--- a/platform/bsd/setlimits.c
+++ b/platform/bsd/setlimits.c
@@ -4,10 +4,13 @@
 void setlimits (struct config profile)
 {
   setlimit (RLIMIT_CORE, profile.core * 1024);
-  setlimit (RLIMIT_STACK, profile.stack * 1024);
   setlimit (RLIMIT_FSIZE, profile.fsize * 1024);
   setlimit (RLIMIT_NPROC, profile.nproc);
   setlimit (RLIMIT_CPU, profile.cpu);
+
+  if (profile.stack > 0) {
+    setlimit (RLIMIT_STACK, profile.stack * 1024);
+  }
 
   /* socket buffer size in bytes */
   setlimit (RLIMIT_SBSIZE, 0);

--- a/platform/linux/setlimits.c
+++ b/platform/linux/setlimits.c
@@ -4,10 +4,13 @@
 void setlimits (struct config profile)
 {
   setlimit (RLIMIT_CORE, profile.core * 1024);
-  setlimit (RLIMIT_STACK, profile.stack * 1024);
   setlimit (RLIMIT_FSIZE, profile.fsize * 1024);
   setlimit (RLIMIT_NPROC, profile.nproc);
   setlimit (RLIMIT_CPU, profile.cpu);
+
+  if (profile.stack > 0) {
+    setlimit (RLIMIT_STACK, profile.stack * 1024);
+  }
 
   /* Address space(including libraries) limit */
   if (profile.aspace > 0)

--- a/safeexec.c
+++ b/safeexec.c
@@ -332,7 +332,7 @@ void printusage (char **p)
            pdefault->nproc);
   fprintf (stderr, "\t--fsize   <kbytes>            Default: %lu kbyte(s)\n",
            pdefault->fsize);
-  fprintf (stderr, "\t--stack   <kbytes>            Default: %lu kbyte(s)\n",
+  fprintf (stderr, "\t--stack   <kbytes>            Default: %lu kbyte(s) - 0 sets no limit\n",
            pdefault->stack);
   fprintf (stderr, "\t--clock   <seconds>           Wall clock timeout (default: %lu)\n",
            pdefault->clock);


### PR DESCRIPTION
safeexec prevents setting an unlimited stack size
directly. Passing `--stack 0` can be used to fall
back to the system-wide configuration.