### PR TITLE
add flag to use VmRSS instead of VmData+VmStk

### DIFF
--- a/memusage.h
+++ b/memusage.h
@@ -1,7 +1,7 @@
 #ifndef MEMUSAGE_H
 #define MEMUSAGE_H
 
-int memusage (pid_t pid);
+int memusage (pid_t pid, bool use_vmrss);
 void memusage_init (void);
 void memusage_close (void);
 

--- a/memusage.h
+++ b/memusage.h
@@ -1,7 +1,7 @@
 #ifndef MEMUSAGE_H
 #define MEMUSAGE_H
 
-int memusage (pid_t pid, bool use_vmrss);
+int memusage (pid_t pid, char use_vmrss);
 void memusage_init (void);
 void memusage_close (void);
 

--- a/platform/bsd/memusage.c
+++ b/platform/bsd/memusage.c
@@ -26,7 +26,7 @@ void memusage_init (void)
     error("memusage_init: %s", errbuf);
 }
 
-int memusage (pid_t pid)
+int memusage (pid_t pid, bool use_vmrss /* unused */)
 {
   struct kinfo_proc *kp;
   int cnt = -1;

--- a/platform/bsd/memusage.c
+++ b/platform/bsd/memusage.c
@@ -26,7 +26,7 @@ void memusage_init (void)
     error("memusage_init: %s", errbuf);
 }
 
-int memusage (pid_t pid, bool use_vmrss /* unused */)
+int memusage (pid_t pid, char use_vmrss /* unused */)
 {
   struct kinfo_proc *kp;
   int cnt = -1;

--- a/platform/linux/memusage.c
+++ b/platform/linux/memusage.c
@@ -15,7 +15,7 @@ void memusage_init (void)
 {
 }
 
-int memusage (pid_t pid, bool use_vmrss)
+int memusage (pid_t pid, char use_vmrss)
 {
   char a[SIZE], *p, *q;
   int data, stack;

--- a/platform/linux/memusage.c
+++ b/platform/linux/memusage.c
@@ -15,7 +15,7 @@ void memusage_init (void)
 {
 }
 
-int memusage (pid_t pid)
+int memusage (pid_t pid, bool use_vmrss)
 {
   char a[SIZE], *p, *q;
   int data, stack;
@@ -44,13 +44,17 @@ int memusage (pid_t pid)
     error (NULL);
 
   data = stack = 0;
-  q = strstr (p, "VmData:");
+  q = strstr (p, use_vmrss ? "VmRSS:" : "VmData:");
   if (q != NULL)
     {
       sscanf (q, "%*s %d", &data);
-      q = strstr (q, "VmStk:");
-      if (q != NULL)
-        sscanf (q, "%*s %d\n", &stack);
+      if (!use_vmrss) {
+        // If we use VmRSS, we don’t need to add
+        // VmStk. That only matters for VmData.
+        q = strstr (q, "VmStk:");
+        if (q != NULL)
+          sscanf (q, "%*s %d\n", &stack);
+      }
     }
 
   return (data + stack);

--- a/safeexec.c
+++ b/safeexec.c
@@ -37,7 +37,7 @@
 #define NICE_LEVEL      15
 #define LARGECONST 4194304
 
-struct config profile = { 1, 32768, 0, 0, 8192, 8192, 0, 10, 5000, 65535 };
+struct config profile = { 1, 32768, 0, 0, 8192, 8192, 0, 10, 5000, 65535, 0 };
 struct config *pdefault = &profile;
 
 pid_t pid;			/* is global, because we kill the proccess in alarm handler */
@@ -212,6 +212,10 @@ char **parse (char **p)
           case PARSE:
             state = INPUT1;
             function = *p;
+            if (strcmp (*p, "--use-vmrss") == 0) {
+              profile.use_vmrss = 1;
+              state = PARSE;
+            }
             if (strcmp (*p, "--cpu") == 0)
               input1 = (unsigned int *) &profile.cpu;
             else if (strcmp (*p, "--mem") == 0)
@@ -509,7 +513,7 @@ int main (int argc, char **argv, char **envp)
           do
             {
               msleep (INTERVAL);
-              memused = memusage (pid);
+              memused = memusage (pid, profile.use_vmrss);
               if (memused > -1)
                 {
                   mem = max (mem, memused);

--- a/safeexec.c
+++ b/safeexec.c
@@ -212,10 +212,6 @@ char **parse (char **p)
           case PARSE:
             state = INPUT1;
             function = *p;
-            if (strcmp (*p, "--use-vmrss") == 0) {
-              profile.use_vmrss = 1;
-              state = PARSE;
-            }
             if (strcmp (*p, "--cpu") == 0)
               input1 = (unsigned int *) &profile.cpu;
             else if (strcmp (*p, "--mem") == 0)
@@ -255,6 +251,11 @@ char **parse (char **p)
             else if (strcmp (*p, "--silent") == 0)
               {
                 silent = 1;
+                state = PARSE;
+              }
+            else if (strcmp (*p, "--use-vmrss") == 0)
+              {
+                profile.use_vmrss = 1;
                 state = PARSE;
               }
             else

--- a/safeexec.c
+++ b/safeexec.c
@@ -253,7 +253,7 @@ char **parse (char **p)
                 silent = 1;
                 state = PARSE;
               }
-            else if (strcmp (*p, "--use-vmrss") == 0)
+            else if (strcmp (*p, "--vmrss") == 0)
               {
                 profile.use_vmrss = 1;
                 state = PARSE;
@@ -344,6 +344,7 @@ void printusage (char **p)
   fprintf (stderr, "\t--usage   <filename>          Report statistics to ... (default: stderr)\n");
   fprintf (stderr, "\t--chroot  <path>              Directory to chrooted (default: /tmp)\n");
   fprintf (stderr, "\t--error   <path>              Print stderr to file (default: /dev/null)\n");
+  fprintf (stderr, "\t--vmrss                       Use VMRSS instead of VmData+VmStk\n");
 }
 
 void wallclock (int v)

--- a/safeexec.h
+++ b/safeexec.h
@@ -19,6 +19,7 @@ struct config
 
   uid_t minuid;
   uid_t maxuid;
+  char use_vmrss;
 };
 
 #endif


### PR DESCRIPTION
# Why?

The current implementation includes virtual memory, which for
VMs like Java can exceed 500MB and had to be hardcoded. This
PR adds a flag to query VMRSS directly for a more accurate
measure of actual memory usage.

# Tests

## Java

```java
public class Main {
    public static void main(String[] args) {
        // Allocate ~8 MB
        byte[] memory = new byte[8 * 1024 * 1024]; // 8 MB

        System.out.println("Allocated " + memory.length + " bytes (~8 MB)");

        try {
            Thread.sleep(5000);
        } catch (InterruptedException e) {
            e.printStackTrace();
        }
    }
}
```

In Java, VMData reports about 150 MB and VRSS about 40 MB — about 32 MB more.
I modified the code above to allocate 20 MB, and VRSS reported 53,876 KB (~52 MB).
This means there is a 32 MB overhead that we need to account for in all Java limits.

```
/ # safeexec --stack 0 \
>     --nproc 20 \
>     --mem 1073741824 \
>     --cpu 10 \
>     --exec \
>     /usr/bin/java Main
Allocated 8388608 bytes (~8 MB)
OK
elapsed time: 5 seconds
memory usage: 155728 kbytes
cpu usage: 0.052 seconds
```

```
/ # safeexec --stack 0 \
>     --nproc 20 \
>     --mem 1073741824 \
>     --cpu 10 \
>     --vmrss \
>     --exec \
>     /usr/bin/java Main
Allocated 8388608 bytes (~8 MB)
OK
elapsed time: 5 seconds
memory usage: 41216 kbytes
cpu usage: 0.064 seconds
```

## C++

```cpp
#include <iostream>
#include <thread>
#include <chrono>

int main() {
    // Allocate ~8 MB
    char* memory = new char[8 * 1024 * 1024]; // 8 MB

    std::cout << "Allocated " << (8) << " MB of memory" << std::endl;

    // Fill memory so it's really allocated
    for (size_t i = 0; i < 8 * 1024 * 1024; i++) {
        memory[i] = 1;
    }

    // Keep the program running so we can check memory usage
    std::this_thread::sleep_for(std::chrono::seconds(5));

    delete[] memory; // free memory
    return 0;
}
```

In C++ both reported about the same, but VMData + VMStk was more
accurate since only 8 MB were allocated. Overall, the difference seems
negligible.

```
/ # safeexec --stack 0 \
>     --nproc 20 \
>     --mem 1073741824 \
>     --cpu 10 \
>     --exec \
>     ./a.out
Allocated 8 MB of memory
OK
elapsed time: 5 seconds
memory usage: 8444 kbytes
cpu usage: 0.016 seconds
```

```
/ # safeexec --stack 0 \
>     --nproc 20 \
>     --mem 1073741824 \
>     --cpu 10 \
>     --vmrss \
>     --exec \
>     ./a.out
Allocated 8 MB of memory
OK
elapsed time: 5 seconds
memory usage: 9948 kbytes
cpu usage: 0.021 seconds
```

## Python

```python
import time

# Allocate ~8 MB
memory = bytearray(8 * 1024 * 1024)  # 8 MB

print(f"Allocated {len(memory)} bytes (~8 MB)")

# Keep program running so we can check memory usage
time.sleep(5)
```

In Python, the difference is 10 MB compared to 12 MB (VMRSS).

```
/ # safeexec --stack 0 \
>     --nproc 20 \
>     --mem 1073741824 \
>     --cpu 10 \
>     --exec \
>     /usr/bin/python3 main.py
Allocated 8388608 bytes (~8 MB)
OK
elapsed time: 5 seconds
memory usage: 10896 kbytes
cpu usage: 0.012 seconds
```

```
/ # safeexec --stack 0 \
>     --nproc 20 \
>     --mem 1073741824 \
>     --cpu 10 \
>     --vmrss \
>     --exec \
>     /usr/bin/python3 main.py
Allocated 8388608 bytes (~8 MB)
OK
elapsed time: 5 seconds
memory usage: 13116 kbytes
cpu usage: 0.021 seconds
```